### PR TITLE
Added rolling / rotating log capability.

### DIFF
--- a/botboy/setup.py
+++ b/botboy/setup.py
@@ -1,22 +1,35 @@
 import logging
+from logging.handlers import TimedRotatingFileHandler
+from logging.handlers import RotatingFileHandler
 
 def setup_logger():
     logger = logging.getLogger()
     if not logger.handlers:
-        logger.setLevel(logging.INFO)
+        logger.setLevel(logging.DEBUG)
 
         fmt_str = '%(asctime)s - %(levelname)s - %(name)s - %(message)s'
         formatter = logging.Formatter(fmt_str)
 
+        # Streaming logs to the console
         if False:
+            sh = logging.StreamHandler()
+            sh.setLevel(logging.INFO)
+            sh.setFormatter(formatter)
+            logger.addHandler(sh)
+
+        # Logging to file (rotating with max size of 100 MB)
+        if True:
             log_path = 'logs/botlogs.log'
-            fh = logging.FileHandler(log_path)
-            fh.setLevel(logging.DEBUG)
+            fh = RotatingFileHandler(log_path, maxBytes=100000000, backupCount=4)
+            fh.setLevel(logging.INFO)
             fh.setFormatter(formatter)
             logger.addHandler(fh)
 
-        sh = logging.StreamHandler()
-        sh.setLevel(logging.INFO)
-        sh.setFormatter(formatter)
+        # Logging to file (rotating with max size of 100 MB)
+        if True:
+            log_path = 'logs/debug_botlogs.log'
+            fh_debug = RotatingFileHandler(log_path, maxBytes=100000000, backupCount=1)
+            fh_debug.setLevel(logging.DEBUG)
+            fh_debug.setFormatter(formatter)
+            logger.addHandler(fh_debug)
 
-        logger.addHandler(sh)


### PR DESCRIPTION
Botboy will now only log to files in the `log/` folder. It will not longer stream logs to the console.
Two separate log files:
- botlogs.log (info level logs)
- debug_botlogs.log (debug level logs)

Still need to update logs and error / crash handling, but that's separate from rolling log capability.